### PR TITLE
Add match requests tab with sample data

### DIFF
--- a/lnl-matcher/src/app/home/home.component.css
+++ b/lnl-matcher/src/app/home/home.component.css
@@ -94,6 +94,41 @@ footer {
   justify-content: flex-end;
 }
 
+.request-card {
+  max-width: none;
+}
+
+nav.subtabs {
+  display: flex;
+  margin-bottom: 12px;
+  gap: 16px;
+}
+
+.subtab {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.subtab.active {
+  text-decoration: underline;
+}
+
+.requests-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.requests-table th,
+.requests-table td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}
+
+.requests-table .actions {
+  gap: 4px;
+}
+
 button.blue {
   background-color: #1976d2;
   color: #fff;

--- a/lnl-matcher/src/app/home/home.component.html
+++ b/lnl-matcher/src/app/home/home.component.html
@@ -44,6 +44,42 @@
         </div>
       </div>
     </div>
+
+    <div *ngIf="activeTab === 'Match Requests'">
+      <div class="match-card request-card">
+        <h2>Match Requests</h2>
+        <nav class="subtabs">
+          <span class="subtab" [class.active]="requestsTab==='Incoming'" (click)="setRequestsTab('Incoming')">Incoming Requests</span>
+          <span class="subtab" [class.active]="requestsTab==='Pending'" (click)="setRequestsTab('Pending')">Pending Matches</span>
+        </nav>
+        <table class="requests-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Department</th>
+              <th>Interests</th>
+              <th>Request Date</th>
+              <th>Scheduled Date</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let r of filteredRequests(); let i = index">
+              <td>{{ r.name }}</td>
+              <td>{{ r.department }}</td>
+              <td>{{ r.interests }}</td>
+              <td>{{ r.requestDate }}</td>
+              <td>{{ r.scheduledDate || '' }}</td>
+              <td class="actions">
+                <button type="button" (click)="openDatePicker(datePickers[i])">Schedule</button>
+                <input type="date" #datePickers style="display:none" (change)="scheduleRequest(r, datePickers.value)">
+                <button type="button" (click)="denyRequest(r)">Deny Request</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </main>
 
   <footer>

--- a/lnl-matcher/src/app/home/home.component.ts
+++ b/lnl-matcher/src/app/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { UserService } from '../user.service';
 
@@ -7,8 +7,17 @@ import { UserService } from '../user.service';
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.css']
 })
-export class HomeComponent {
+interface MatchRequest {
+  name: string;
+  department: string;
+  interests: string;
+  requestDate: string;
+  scheduledDate?: string;
+}
+
+export class HomeComponent implements OnInit {
   activeTab = 'Match';
+  requestsTab = 'Incoming';
   departments = [
     'Viztech',
     'Reporting',
@@ -31,6 +40,68 @@ export class HomeComponent {
   interest = '';
   interests: string[] = [];
   showSuccess = false;
+
+  matchRequests: MatchRequest[] = [];
+
+  ngOnInit() {
+    const data = localStorage.getItem('matchRequests');
+    if (data) {
+      this.matchRequests = JSON.parse(data);
+    } else {
+      this.generateSampleRows();
+    }
+  }
+
+  private saveRequests() {
+    localStorage.setItem('matchRequests', JSON.stringify(this.matchRequests));
+  }
+
+  private generateSampleRows() {
+    const samples: MatchRequest[] = [];
+    for (let i = 1; i <= 5; i++) {
+      samples.push({
+        name: `User ${i}`,
+        department: this.departments[i % this.departments.length],
+        interests: 'Interest ' + i,
+        requestDate: new Date().toISOString().slice(0, 10),
+      });
+    }
+    this.matchRequests = samples;
+    this.saveRequests();
+  }
+
+  setRequestsTab(tab: string) {
+    this.requestsTab = tab;
+  }
+
+  filteredRequests() {
+    return this.matchRequests.filter(r =>
+      this.requestsTab === 'Incoming' ? !r.scheduledDate : !!r.scheduledDate
+    );
+  }
+
+  openDatePicker(input: HTMLInputElement) {
+    if ((input as any).showPicker) {
+      (input as any).showPicker();
+    } else {
+      input.click();
+    }
+  }
+
+  scheduleRequest(req: MatchRequest, date: string) {
+    if (date) {
+      req.scheduledDate = date;
+      this.saveRequests();
+    }
+  }
+
+  denyRequest(req: MatchRequest) {
+    const index = this.matchRequests.indexOf(req);
+    if (index >= 0) {
+      this.matchRequests.splice(index, 1);
+      this.saveRequests();
+    }
+  }
 
   constructor(public userService: UserService, private router: Router) {}
 


### PR DESCRIPTION
## Summary
- add interface and storage logic for match requests
- generate sample rows on first load
- show and schedule/deny requests in a new Match Requests tab
- persist table edits in local storage

## Testing
- `npm test` *(fails: ng not found)*