### PR TITLE
Implement match request scheduling

### DIFF
--- a/lnl-matcher/src/app/home/home.component.css
+++ b/lnl-matcher/src/app/home/home.component.css
@@ -110,3 +110,14 @@ button {
   background: #fff;
   cursor: pointer;
 }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}

--- a/lnl-matcher/src/app/home/home.component.html
+++ b/lnl-matcher/src/app/home/home.component.html
@@ -44,6 +44,35 @@
         </div>
       </div>
     </div>
+
+    <div *ngIf="activeTab === 'Match Requests'" class="match-card">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Department</th>
+            <th>Interests</th>
+            <th>Request Date</th>
+            <th>Scheduled Date</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let r of requests; let i = index">
+            <td>{{ r.name }}</td>
+            <td>{{ r.department }}</td>
+            <td>{{ r.interests }}</td>
+            <td>{{ r.requestDate }}</td>
+            <td>{{ r.scheduledDate || '' }}</td>
+            <td>
+              <input #picker type="date" (change)="setSchedule(r, picker.value)" hidden>
+              <button type="button" (click)="openDatePicker(picker)">Schedule</button>
+              <button type="button" (click)="denyRequest(i)">Deny Request</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </main>
 
   <footer>

--- a/lnl-matcher/src/app/home/home.component.ts
+++ b/lnl-matcher/src/app/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { UserService } from '../user.service';
 
@@ -7,7 +7,15 @@ import { UserService } from '../user.service';
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.css']
 })
-export class HomeComponent {
+interface MatchRequest {
+  name: string;
+  department: string;
+  interests: string;
+  requestDate: string;
+  scheduledDate?: string;
+}
+
+export class HomeComponent implements OnInit {
   activeTab = 'Match';
   departments = [
     'Viztech',
@@ -31,8 +39,19 @@ export class HomeComponent {
   interest = '';
   interests: string[] = [];
   showSuccess = false;
+  requests: MatchRequest[] = [];
 
   constructor(public userService: UserService, private router: Router) {}
+
+  ngOnInit() {
+    const stored = localStorage.getItem('matchRequests');
+    if (stored) {
+      this.requests = JSON.parse(stored);
+    } else {
+      this.requests = this.generateSampleRequests();
+      this.saveRequests();
+    }
+  }
 
   setTab(tab: string) {
     this.activeTab = tab;
@@ -60,5 +79,41 @@ export class HomeComponent {
   logout() {
     this.userService.clearUser();
     this.router.navigate(['/']);
+  }
+
+  openDatePicker(input: HTMLInputElement) {
+    if ((input as any).showPicker) {
+      (input as any).showPicker();
+    } else {
+      input.focus();
+      input.click();
+    }
+  }
+
+  setSchedule(req: MatchRequest, date: string) {
+    req.scheduledDate = date;
+    this.saveRequests();
+  }
+
+  denyRequest(index: number) {
+    this.requests.splice(index, 1);
+    this.saveRequests();
+  }
+
+  private saveRequests() {
+    localStorage.setItem('matchRequests', JSON.stringify(this.requests));
+  }
+
+  private generateSampleRequests(): MatchRequest[] {
+    const samples: MatchRequest[] = [];
+    for (let i = 1; i <= 5; i++) {
+      samples.push({
+        name: `User ${i}`,
+        department: this.departments[(i - 1) % this.departments.length],
+        interests: `Interest ${i}`,
+        requestDate: new Date().toLocaleDateString(),
+      });
+    }
+    return samples;
   }
 }


### PR DESCRIPTION
## Summary
- add interface and logic for match request management
- persist rows in local storage and generate sample data
- allow scheduling and denying requests
- show match requests table below tabs
- style table for readability

## Testing
- `npm test --silent` *(fails: ng not found)*