### PR TITLE
Implement pending requests tab

### DIFF
--- a/lnl-matcher/src/app/home/home.component.html
+++ b/lnl-matcher/src/app/home/home.component.html
@@ -5,8 +5,7 @@
   </header>
   <nav class="tabs">
     <span class="tab" (click)="setTab('Match')">Match</span>
-    <span class="tab" (click)="setTab('Match Requests')">Match Requests</span>
-    <span class="tab" (click)="setTab('Schedule')">Schedule</span>
+    <span class="tab" (click)="setTab('Pending Requests')">Pending Requests</span>
     <span class="tab" (click)="setTab('Match History')">Match History</span>
   </nav>
 
@@ -53,7 +52,7 @@
       </div>
     </div>
 
-    <div *ngIf="activeTab === 'Match Requests'" class="match-card">
+    <div *ngIf="activeTab === 'Pending Requests'" class="match-card">
       <table>
         <thead>
           <tr>
@@ -61,7 +60,8 @@
             <th>Department</th>
             <th>Interests</th>
             <th>Request Date</th>
-            <th>Scheduled Date</th>
+            <th>Status</th>
+            <th>Schedule Date</th>
             <th>Actions</th>
           </tr>
         </thead>
@@ -71,10 +71,12 @@
             <td>{{ r.department }}</td>
             <td>{{ r.interests }}</td>
             <td>{{ r.requestDate }}</td>
+            <td>{{ r.status }}</td>
             <td>{{ r.scheduledDate || '' }}</td>
             <td>
               <input #picker type="date" (change)="setSchedule(r, picker.value)" hidden>
               <button type="button" (click)="openDatePicker(picker)">Schedule</button>
+              <button type="button" (click)="acceptRequest(r)">Accept</button>
               <button type="button" (click)="denyRequest(i)">Deny Request</button>
             </td>
           </tr>

--- a/lnl-matcher/src/app/home/home.component.ts
+++ b/lnl-matcher/src/app/home/home.component.ts
@@ -7,6 +7,7 @@ interface MatchRequest {
   department: string;
   interests: string;
   requestDate: string;
+  status: 'pending' | 'accepted' | 'scheduled';
   scheduledDate?: string;
 }
 
@@ -85,6 +86,14 @@ export class HomeComponent implements OnInit {
   }
 
   confirmMatch() {
+    this.requests.push({
+      name: this.matchName,
+      department: this.matchDept,
+      interests: this.matchingInterests.join(', '),
+      requestDate: new Date().toLocaleDateString(),
+      status: 'pending'
+    });
+    this.saveRequests();
     this.resetForm();
   }
 
@@ -108,11 +117,17 @@ export class HomeComponent implements OnInit {
 
   setSchedule(req: MatchRequest, date: string) {
     req.scheduledDate = date;
+    req.status = 'scheduled';
     this.saveRequests();
   }
 
   denyRequest(index: number) {
     this.requests.splice(index, 1);
+    this.saveRequests();
+  }
+
+  acceptRequest(req: MatchRequest) {
+    req.status = 'accepted';
     this.saveRequests();
   }
 
@@ -128,6 +143,7 @@ export class HomeComponent implements OnInit {
         department: this.departments[(i - 1) % this.departments.length],
         interests: `Interest ${i}`,
         requestDate: new Date().toLocaleDateString(),
+        status: 'pending'
       });
     }
     return samples;


### PR DESCRIPTION
## Summary
- rename navigation to Pending Requests
- track request status and schedule date
- add Accept button and scheduling to table
- persist pending requests when confirming a match

## Testing
- `npm test` *(fails: ng not found)*