### PR TITLE
Add subtle Elon Musk reference

### DIFF
--- a/lnl-matcher/src/app/home/home.component.css
+++ b/lnl-matcher/src/app/home/home.component.css
@@ -160,3 +160,8 @@ th, td {
   padding: 8px;
   text-align: left;
 }
+
+.secret-elon {
+  color: #f9f9f9;
+  font-size: 6px;
+}

--- a/lnl-matcher/src/app/home/home.component.html
+++ b/lnl-matcher/src/app/home/home.component.html
@@ -142,6 +142,7 @@
     <div class="left">Contact 📞</div>
     <div class="center">Vizient L&L Matcher, All rights reserved ©️</div>
     <div class="right">Help ❔</div>
+    <span class="secret-elon">Elon Musk</span>
   </footer>
 
   <div class="clippy">


### PR DESCRIPTION
## Summary
- add a tiny hidden 'Elon Musk' text in the Home page footer
- style the secret text to blend into the background

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6839fa47f7dc832ea07660992672d77a